### PR TITLE
add time-grunt

### DIFF
--- a/templates/Gruntfile.js
+++ b/templates/Gruntfile.js
@@ -67,6 +67,8 @@ module.exports = function (grunt) {
   //
   // load all grunt tasks
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  // show elapsed time at the end
+  require('time-grunt')(grunt);
 
   grunt.initConfig({
     watch: {

--- a/templates/_package.json
+++ b/templates/_package.json
@@ -34,7 +34,8 @@
     "grunt-mocha": "~0.3.0",
     "chai": "~1.5.0",
     "chai-as-promised": "~3.2.5",
-    "superstartup-closure-compiler": "~0.1.5"
+    "superstartup-closure-compiler": "~0.1.5",
+    "time-grunt": "~0.1.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
[time-grunt](https://github.com/sindresorhus/time-grunt) displays the elapsed execution time of grunt tasks. We're using it in [generator-webapp](https://github.com/yeoman/generator-webapp/blob/master/app/templates/Gruntfile.js#L11-L12).
